### PR TITLE
Carousel effect to US-COVID-19 landing page

### DIFF
--- a/dimagi/pages/templates/sections/us_covid_19/case_study/case_study.html
+++ b/dimagi/pages/templates/sections/us_covid_19/case_study/case_study.html
@@ -43,25 +43,15 @@
         {% include "sections/us_covid_19/case_study/departments.html" %}
       </div>{# .content #}
       <div class="content content-width-large pad-vert-medium">
-        <blockquote>
-          <p>
-            {% blocktrans %}
-              In the midst of an unprecedented disease outbreak, experience
-              matters. While there were no pandemic-ready, turn-key contact
-              tracing systems available, the Philadelphia Department of Public
-              Health benefited from the expertise Dimagi gained from developing
-              COVID-19 data systems for public health agencies. We are pleased
-              with the COVID-19 case investigation and contact tracing application
-              they built for us in their CommCare software system and feel it has
-              facilitated our ability to respond to the pandemic.
-            {% endblocktrans %}
-          </p>
-          <cite class="content-width-extra-small">
-            {% blocktrans %}
-              - Philadelphia Department of Public Health
-            {% endblocktrans %}
-          </cite>
-        </blockquote>
+        <div class="carousel carousel-fade-inactive carousel-numbered carousel-features">
+          <div class="carousel-container">
+            <div class="spinner spinner-large"></div>
+            <div class="carousel-slider">
+              {% include "sections/us_covid_19/case_study/testimonials/pdph.html" %}
+              {% include "sections/us_covid_19/case_study/testimonials/nydh.html" %}
+            </div>{# .carousel-slider #}
+          </div>{# .carousel-container #}
+        </div>{# .carousel #}
       </div>
     </div>    
   </div>

--- a/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/_base.html
+++ b/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/_base.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load dimagidotcom %}
+
+<div class="carousel-slide pad-horz-base pad-vert-small pad-horz-small-at-medium pad-vert-medium-at-medium border-vert border-horz">
+
+  <div class="pad-horz-line">
+    {% block content %}{% endblock %}
+  </div>
+
+{#  <div class="carousel-arrow previous"></div>#}
+{#  <div class="carousel-arrow next"></div>#}
+</div>

--- a/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/nydh.html
+++ b/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/nydh.html
@@ -1,0 +1,23 @@
+{% extends "sections/us_covid_19/case_study/testimonials/_base.html" %}
+{% load i18n %}
+{% load dimagidotcom %}
+
+{% block content %}
+  <div class="testimonial-content content-width-medium align-left pad-horz-small">
+    <blockquote>
+      <p class="pad-bottom-line">
+        {% blocktrans %}
+          The powerful combination of Dimagi’s public health expertise, coupled 
+          with cloud-based technology, has allowed us to regularly improve our 
+          contact tracing application based on feedback from public health 
+          officials with speed and agility as this pandemic evolves.
+        {% endblocktrans %}  
+      </p>
+      <cite class="content-width-small">
+        {% blocktrans %}
+          - Mahesh Nattanmai, Chief Health Information Officer, New York State Department of Health
+        {% endblocktrans %}
+      </cite>
+    </blockquote>
+  </div>
+{% endblock %}

--- a/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/pdph.html
+++ b/dimagi/pages/templates/sections/us_covid_19/case_study/testimonials/pdph.html
@@ -1,0 +1,27 @@
+{% extends "sections/us_covid_19/case_study/testimonials/_base.html" %}
+{% load i18n %}
+{% load dimagidotcom %}
+
+{% block content %}
+  <div class="testimonial-content content-width-medium align-left pad-horz-small">
+    <blockquote>
+      <p class="pad-bottom-line">
+        {% blocktrans %}
+          In the midst of an unprecedented disease outbreak, experience
+          matters. While there were no pandemic-ready, turn-key contact
+          tracing systems available, the Philadelphia Department of Public
+          Health benefited from the expertise Dimagi gained from developing
+          COVID-19 data systems for public health agencies. We are pleased
+          with the COVID-19 case investigation and contact tracing application
+          they built for us in their CommCare software system and feel it has
+          facilitated our ability to respond to the pandemic.
+        {% endblocktrans %}  
+      </p>
+      <cite class="content-width-extra-small">
+        {% blocktrans %}
+          - Philadelphia Department of Public Health
+        {% endblocktrans %}
+      </cite>
+    </blockquote>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Added Carousel effect to the US-COVID-19 landing page(https://dimagi.com/covid-19/us-response), In the Responding Across the United States section.