### PR TITLE
Added missing link in sub nav

### DIFF
--- a/dimagi/pages/templates/sections/covid_19/sub_nav.html
+++ b/dimagi/pages/templates/sections/covid_19/sub_nav.html
@@ -29,7 +29,7 @@
             Covid-19 solutions
           {% endblocktrans %}
         </a>
-        <a href="#resources"
+        <a href="#response"
            class="{% click_subnav 'resources' %}">
           {% blocktrans %}
             Resources


### PR DESCRIPTION
Added link to  "Resources" in  subnav button on COVID-19 Landing Page:

https://dimagi.com/covid-19/